### PR TITLE
Corrige el error final de despliegue en GitHub Pages causado por una …

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
   "name": "my-v0-project",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://SayriDevs.github.io/HOTELES-ROSAS",
+  "homepage": "https://sayridevs.github.io/HOTELES-ROSAS",
   "scripts": {
     "dev": "next dev",
-    "build": "next build && cp public/.nojekyll out/.nojekyll",
+    "build": "next build",
     "build:local": "next build",
     "serve": "npx serve out",
     "lint": "next lint",
     "start": "next start",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d out"
+    "deploy": "gh-pages -d out --dotfiles"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
…discrepancia de mayúsculas y minúsculas en la URL del campo `homepage` en `package.json`.

Cambios:
1.  **`package.json`**: Se corrige la URL en `homepage` de `SayriDevs` a `sayridevs` para que coincida con la URL real de GitHub, que es sensible a mayúsculas y minúsculas para estas operaciones.
2.  **`package.json`**: Se simplifica el script `build` eliminando la copia manual de `.nojekyll`, ya que es una responsabilidad del proceso de despliegue.
3.  **`package.json`**: Se robustece el script `deploy` añadiendo el flag `--dotfiles` para asegurar que `gh-pages` incluya el archivo `.nojekyll` durante el despliegue.

Esta combinación de cambios resuelve la causa raíz por la que los recursos (CSS/JS) no se cargaban a pesar de tener las rutas prefijadas correctamente.